### PR TITLE
fix: missing deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   },
   "peerDependencies": {
     "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "commander": "^13.1.0"
   }
 }


### PR DESCRIPTION
跑 `bun install` 時會報錯：

```sh
6 | import { Command } from 'commander';
                            ^
error: Could not resolve: "commander". Maybe you need to "bun install"?
```